### PR TITLE
feat(uat): add and remove steps for loopback address

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/NetworkUtilsSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/NetworkUtilsSteps.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.testing.platform.Platform;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.After;
 import io.cucumber.java.ParameterType;
+import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +76,32 @@ public class NetworkUtilsSteps {
                 platform.networkUtils().disconnectMqtt();
             }
         }
+    }
+
+    /**
+     * Add loop back address.
+     *
+     * @param address the value of loop back address
+     * @throws IOException on IO errors
+     * @throws InterruptedException when thread has been interrupted
+     */
+    @Then("I add loop back address {string}")
+    public void addLoopBackAddress(final String address) throws IOException, InterruptedException {
+        LOGGER.info("Adding loopback address {}", address);
+        platform.networkUtils().addLoopbackAddress(address);
+    }
+
+    /**
+     * Delete loop back address.
+     *
+     * @param address the value of loop back address
+     * @throws IOException on IO errors
+     * @throws InterruptedException when thread has been interrupted
+     */
+    @Then("I remove loop back address {string}")
+    public void deleteLoopBackAddress(final String address) throws IOException, InterruptedException {
+        LOGGER.info("Deleting loopback address {}", address);
+        platform.networkUtils().deleteLoopbackAddress(address);
     }
 
     /**

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/NetworkUtilsSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/NetworkUtilsSteps.java
@@ -79,27 +79,27 @@ public class NetworkUtilsSteps {
     }
 
     /**
-     * Add loop back address.
+     * Add IP address to loopback interface.
      *
      * @param address the value of loop back address
      * @throws IOException on IO errors
      * @throws InterruptedException when thread has been interrupted
      */
-    @Then("I add loop back address {string}")
+    @Then("I add IP address {string} to loopback interface")
     public void addLoopBackAddress(final String address) throws IOException, InterruptedException {
         LOGGER.info("Adding loopback address {}", address);
         platform.networkUtils().addLoopbackAddress(address);
     }
 
     /**
-     * Delete loop back address.
+     * Remove IP address from loopback interface.
      *
      * @param address the value of loop back address
      * @throws IOException on IO errors
      * @throws InterruptedException when thread has been interrupted
      */
-    @Then("I remove loop back address {string}")
-    public void deleteLoopBackAddress(final String address) throws IOException, InterruptedException {
+    @Then("I remove IP address {string} from loopback interface")
+    public void removeLoopBackAddress(final String address) throws IOException, InterruptedException {
         LOGGER.info("Deleting loopback address {}", address);
         platform.networkUtils().deleteLoopbackAddress(address);
     }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
@@ -13,4 +13,8 @@ public abstract class NetworkUtils {
     public abstract void disconnectMqtt() throws InterruptedException, IOException;
 
     public abstract void recoverMqtt() throws InterruptedException, IOException;
+
+    public abstract void addLoopbackAddress(String address) throws IOException, InterruptedException;
+
+    public abstract void deleteLoopbackAddress(String address) throws IOException, InterruptedException;
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.api.device.Device;
-import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.model.PillboxContext;
 import com.aws.greengrass.testing.platform.NetworkUtils;
@@ -17,7 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class LinuxNetworkUtils extends NetworkUtils {
     private static final Logger LOGGER = LogManager.getLogger(LinuxNetworkUtils.class);
@@ -26,6 +24,7 @@ public class LinuxNetworkUtils extends NetworkUtils {
     private static final String DISABLE_OPTION = "--delete";
     private static final String APPEND_OPTION = "-A";
     private static final String IPTABLES = "iptables";
+    private static final String IP = "ip";
     private static final String[] TEMPLATES = {
         "INPUT -p tcp -s 127.0.0.1 --dport %s -j ACCEPT",
         "INPUT -p tcp --dport %s -j DROP",
@@ -33,6 +32,8 @@ public class LinuxNetworkUtils extends NetworkUtils {
         "OUTPUT -p tcp --dport %s -j DROP"
     };
 
+    private static final String ADD_LOOPBACK_ADDRESS_TEMPLATE = "addr add %s/32 dev lo";
+    private static final String DELETE_LOOPBACK_ADDRESS_TEMPLATE = "addr delete %s/32 dev lo";
     private static final String COMMAND_FAILED_TO_RUN = "Command (%s) failed to run.";
 
     private final LinuxCommands commands;
@@ -49,6 +50,31 @@ public class LinuxNetworkUtils extends NetworkUtils {
     @Override
     public void recoverMqtt() throws InterruptedException, IOException {
         modifyMqttConnection(DISABLE_OPTION);
+    }
+
+    @Override
+    public void addLoopbackAddress(String address) {
+        String cmd = String.format(ADD_LOOPBACK_ADDRESS_TEMPLATE, address);
+
+        CommandInput commandInput = CommandInput.builder()
+                .line(IP)
+                .addArgs(cmd)
+                .timeout(TIMEOUT_IN_SECONDS)
+                .build();
+
+        commands.execute(commandInput);
+    }
+
+    @Override
+    public void deleteLoopbackAddress(String address) {
+        String cmd = String.format(DELETE_LOOPBACK_ADDRESS_TEMPLATE, address);
+        CommandInput commandInput = CommandInput.builder()
+                .line(IP)
+                .addArgs(cmd)
+                .timeout(TIMEOUT_IN_SECONDS)
+                .build();
+
+        commands.execute(commandInput);
     }
 
     private void modifyMqttConnection(String action) throws IOException, InterruptedException {

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosNetworkUtils.java
@@ -19,4 +19,14 @@ public class MacosNetworkUtils extends NetworkUtils {
     public void recoverMqtt() throws InterruptedException, IOException {
         throw new UnsupportedOperationException("Operation not supported");
     }
+
+    @Override
+    public void addLoopbackAddress(String address) {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
+
+    @Override
+    public void deleteLoopbackAddress(String address) {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsNetworkUtils.java
@@ -24,6 +24,9 @@ public class WindowsNetworkUtils extends NetworkUtils {
         "advfirewall firewall add rule name='%s' protocol=tcp dir=out action=block remoteport=%s"
     };
 
+    private static final String NETSH_ADD_LOOPBACK_ADDRESS = "interface ipv4 add address loopback %s mask=255.0.0.0";
+    private static final String NETSH_DELETE_LOOPBACK_ADDRESS = "interface ipv4 delete address loopback %s";
+
     private static final String NETSH_DELETE_RULE_FORMAT_STR
         = "advfirewall firewall delete rule name='%s'";
 
@@ -50,6 +53,18 @@ public class WindowsNetworkUtils extends NetworkUtils {
     @Override
     public void recoverMqtt() throws InterruptedException, IOException {
         deleteRules(MQTT_PORTS);
+    }
+
+    @Override
+    public void addLoopbackAddress(String address) throws IOException, InterruptedException {
+        String command = String.format(NETSH_ADD_LOOPBACK_ADDRESS, address);
+        runNetshCommand(command, false);
+    }
+
+    @Override
+    public void deleteLoopbackAddress(String address) throws IOException, InterruptedException {
+        String command = String.format(NETSH_DELETE_LOOPBACK_ADDRESS, address);
+        runNetshCommand(command, false);
     }
 
     private String getRuleName(String port) {


### PR DESCRIPTION
**Issue #, if available:**
https://klika-tech.atlassian.net/browse/GGMQ-203
add and remove steps for loopback address

**Description of changes:**
- Add add loopback address steps
- Add remove loopback address steps


**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Run scenario on CodeBuild

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "basic_connect"..................................passed
When I associate "basic_connect" with ggc...................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I add loop back address "127.0.0.2"....................................passed
Then I wait 90 seconds......................................................passed
And I discover core device broker as "default_broker" from "basic_connect" in OTF.passed
And I connect device "basic_connect" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
And I disconnect device "basic_connect" with reason code 0..................passed
Then I remove loop back address "127.0.0.2".................................passed
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
